### PR TITLE
Pin patched PostCSS

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
   "pnpm": {
     "overrides": {
       "lodash": "^4.17.23",
+      "postcss": "^8.5.10",
       "yaml": "^2.8.3"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   lodash: ^4.17.23
+  postcss: ^8.5.10
   yaml: ^2.8.3
 
 importers:
@@ -1987,8 +1988,8 @@ packages:
   postcss-value-parser@4.2.0:
     resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
 
-  postcss@8.5.9:
-    resolution: {integrity: sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==}
+  postcss@8.5.12:
+    resolution: {integrity: sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==}
     engines: {node: ^10 || ^12 || >=14}
 
   prettier-plugin-astro@0.14.1:
@@ -4907,7 +4908,7 @@ snapshots:
 
   postcss-value-parser@4.2.0: {}
 
-  postcss@8.5.9:
+  postcss@8.5.12:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -5402,7 +5403,7 @@ snapshots:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
-      postcss: 8.5.9
+      postcss: 8.5.12
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:


### PR DESCRIPTION
## Description

Dependabot alert 66 reports GHSA-qx2v-qp2m-jg93 for PostCSS versions
below 8.5.10. The project resolves PostCSS transitively through Vite,
which is used by Astro and Vitest, so the lockfile needs a patched
resolution while upstream packages still allow the vulnerable version.

## Changes

This PR will:

- Pin PostCSS to the patched range through the existing pnpm overrides
  block.
- Refresh the pnpm lockfile so Vite resolves PostCSS 8.5.12.
- Keep the installed graph at one PostCSS version.

Validation:

- `pnpm install --frozen-lockfile`
- `pnpm run check`
- `pnpm run build`
- `pnpm run test`
- `pnpm audit --audit-level=moderate`

## Related

- https://github.com/br3ndonland/br3ndonland.github.io/security/dependabot/66
- GHSA-qx2v-qp2m-jg93
