### PR TITLE
Upgrade project to pnpm 11

### DIFF
--- a/.devcontainer/bootstrap.mjs
+++ b/.devcontainer/bootstrap.mjs
@@ -58,13 +58,8 @@ const hasCommand = (command) => {
 }
 
 try {
-  for (const command of ["git", "git-lfs", "pnpm"]) {
+  for (const command of ["git", "git-lfs", "corepack"]) {
     if (hasCommand(command)) {
-      continue
-    }
-
-    if (command === "pnpm") {
-      run("npm", ["install", "--global", "pnpm@latest-10"])
       continue
     }
 
@@ -99,21 +94,21 @@ try {
   }
 
   log("Installing dependencies...")
-  run("pnpm", ["install", "--frozen-lockfile"], {
+  run("corepack", ["pnpm", "install", "--frozen-lockfile"], {
     env: {
       ...process.env,
       CI: "true",
     },
   })
-  run("pnpm", ["run", "astro", "telemetry", "disable"])
+  run("corepack", ["pnpm", "run", "astro", "telemetry", "disable"])
   log("Dependencies installed.")
 
   log("Running repository checks...")
-  run("pnpm", ["run", "check"])
+  run("corepack", ["pnpm", "run", "check"])
   log("Checks complete.")
 
   log("Running production build...")
-  run("pnpm", ["run", "build"])
+  run("corepack", ["pnpm", "run", "build"])
   log("Build complete.")
 
   log("Done.")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
         with:
           lfs: true
       - uses: pnpm/action-setup@v5
-        with:
-          version: ${{ vars.PNPM_VERSION }}
       - uses: actions/setup-node@v6
         with:
           node-version-file: package.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "bws",
   "license": "UNLICENSED",
+  "packageManager": "pnpm@11.0.9",
   "private": true,
   "type": "module",
   "version": "0.0.0",
@@ -65,13 +66,5 @@
     "prettier": "~3.6.2",
     "prettier-plugin-astro": "^0.14.1",
     "vitest": "~4.1.4"
-  },
-  "pnpm": {
-    "overrides": {
-      "fast-uri": "^3.1.2",
-      "lodash": "^4.17.23",
-      "postcss": "^8.5.10",
-      "yaml": "^2.8.3"
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+allowBuilds:
+  core-js: false
+  esbuild: true
+  sharp: true
+
+overrides:
+  fast-uri: ^3.1.2
+  lodash: ^4.17.23
+  postcss: ^8.5.10
+  yaml: ^2.8.3


### PR DESCRIPTION
## Description

pnpm 11 changes where project configuration is read from. The current
main branch stores pnpm overrides in package.json#pnpm, installs a pnpm
10 release-line fallback in the devcontainer bootstrap script, and
provides the pnpm version to GitHub Actions through the PNPM_VERSION
repository variable. pnpm 11 requires the project to move pnpm-specific
config into pnpm-workspace.yaml, and packageManager can be the single
source for the exact pnpm version used by local Corepack, GitHub
Actions, and Vercel.

## Changes

This PR will:

- Pin packageManager to pnpm 11.0.9.
- Move pnpm overrides from package.json to pnpm-workspace.yaml.
- Add pnpm 11 allowBuilds decisions for core-js, esbuild, and sharp.
- Remove the GitHub Actions PNPM_VERSION workflow input so
  pnpm/action-setup reads packageManager.
- Update devcontainer bootstrap commands to require Corepack and run
  pnpm through packageManager instead of installing pnpm@latest-10
  globally.

The Vercel project configuration has also been updated outside the merge
diff with ENABLE_EXPERIMENTAL_COREPACK=1 for Production, Preview, and
Development so Vercel reads packageManager during installs and builds.

<details><summary>Validation</summary>

```text
pnpm install --frozen-lockfile
pnpm run check
pnpm run build
pnpm run test
pnpm run build --site "https://br3ndonland.github.io"
node --check .devcontainer/bootstrap.mjs
```

</details>

## Related

- [pnpm v10 to v11 migration guide](https://pnpm.io/migration)
- [pnpm 11.0 release post](https://pnpm.io/blog/releases/11.0)
- [pnpm/action-setup packageManager docs](https://github.com/pnpm/action-setup/blob/v5/README.md)
- [Vercel Corepack configuration](https://vercel.com/docs/builds/configure-a-build#corepack)