### PR TITLE
Cache Astro image assets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,22 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm run check
       - run: pnpm run test
+      - name: Restore Astro image cache
+        id: astro-image-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: node_modules/.astro/assets
+          key: >-
+            astro-assets-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('astro.config.ts', 'package.json', 'pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+          restore-keys: |
+            astro-assets-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('astro.config.ts', 'package.json', 'pnpm-lock.yaml') }}-
       - run: pnpm run build --site "https://${GITHUB_REPOSITORY##*/}"
+      - name: Save Astro image cache
+        if: steps.astro-image-cache.outputs.cache-hit != 'true'
+        uses: actions/cache/save@v6
+        with:
+          path: node_modules/.astro/assets
+          key: ${{ steps.astro-image-cache.outputs.cache-primary-key }}
       - name: Upload build artifact
         if: github.ref == 'refs/heads/main' || github.ref_type == 'tag'
         uses: actions/upload-pages-artifact@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
         with:
           path: node_modules/.astro/assets
           key: >-
-            astro-assets-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('astro.config.ts', 'package.json', 'pnpm-lock.yaml') }}-${{ hashFiles('src/**') }}
+            astro-assets-${{ runner.os }}-${{ hashFiles('src/**') }}
           restore-keys: |
-            astro-assets-v1-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('astro.config.ts', 'package.json', 'pnpm-lock.yaml') }}-
+            astro-assets-${{ runner.os }}-
       - run: pnpm run build --site "https://${GITHUB_REPOSITORY##*/}"
       - name: Save Astro image cache
         if: steps.astro-image-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Description

GitHub Actions currently rebuilds all optimized Astro images on every
run, even though Astro stores reusable processed assets in its cache
directory. Recent workflows spend around three minutes in this phase.

## Changes

This PR will:

- Restore Astro image assets before production builds.
- Key cache snapshots by runner OS and `src/**` content.
- Save expanded cache snapshots after successful builds.

The key intentionally omits runner architecture, dependency metadata,
and Astro configuration. This keeps cached images reusable across
routine dependency and configuration changes. It retains `src/**`,
rather than only `src/images/**`, because image transform requests can
also change in Astro, MDX, and TypeScript source files.

This follows the broad restore strategy used by
[`withastro/action`](https://github.com/withastro/action/blob/main/action.yml):
restore an Astro cache using an OS-scoped prefix. The action uses a
per-commit primary key and caches all of `node_modules/.astro`; this
workflow uses an OS and source-content key and caches only processed
image assets. Commits without source changes can therefore reuse an
exact cache entry instead of saving another snapshot.

The tradeoff is that an Astro, Sharp, image-service, or configuration
upgrade can reuse images produced by an earlier toolchain. Astro keys
entries by image source and requested transform, but an optimizer-only
change might not invalidate an existing entry. Also, because GitHub
caches are immutable, dependency-only changes cannot save additions when
the source key is an exact hit. Change the `astro-assets-` prefix when
an upgrade requires a fully fresh cache.

<details><summary>Validation</summary>

```text
pnpm install --frozen-lockfile: passed
pnpm run check: passed
pnpm run build: passed (243 cache entries reused; 36 ms image phase)
pnpm run test: passed (23 tests)
GitHub Actions simplified-key cold run: passed (5m33s; cache saved; 4m31s image phase)
GitHub Actions simplified-key exact-hit rerun: passed (48s; 243 entries reused; 285 ms image phase)
```

</details>

## Related

- [Astro asset caching](https://docs.astro.build/en/guides/images/#asset-caching)
- [GitHub Actions cache](https://github.com/actions/cache)
- [withastro/action](https://github.com/withastro/action)
